### PR TITLE
ch-fix bug that exposed user passwords while returning user data

### DIFF
--- a/auth/serializers.py
+++ b/auth/serializers.py
@@ -10,7 +10,7 @@ class UserSerializer(HyperlinkedModelSerializer):
         fields = ('url', 'username', 'email', 'password',
                   'first_name', 'last_name', 'date_joined')
         extra_kwargs = {'email': {'allow_blank': False, 'required': True, 'validators': [
-            UniqueValidator(queryset=User.objects.all())]}}
+            UniqueValidator(queryset=User.objects.all())]},'password': {'write_only': True}}
 
     def create(self, validated_data):
         username = validated_data['username']


### PR DESCRIPTION
### What does this PR do?
- fixes a bug where the system was returning the user's password with the user data

### Description of task/tasks to be completed
- Add write_only kwarg  to extra_kwargs in the UserSerializer class

### How to manually test this
run==> python manage.py runserver and login to request for users on this endpoint
http://127.0.0.1:8000/api/v1/users/


##Reviewers
@fodongkara @nadralia @llwasampijja @engjames @JamesMudidi 